### PR TITLE
Pokédex API at /api/v1/ for RAPP_Sense_Store — third store adopts the pattern

### DIFF
--- a/api/v1/index.json
+++ b/api/v1/index.json
@@ -1,0 +1,81 @@
+{
+  "schema": "rapp-sense-pokedex-api/1.0",
+  "name": "RAPP_Sense_Store Pok\u00e9dex API",
+  "description": "Static catalog API for RAPP sense overlays \u2014 per-channel output transformers that the brainstem installs into utils/senses/. Mirrors the RAPP_Store + RAR API shape so the rapp-zoo can browse all federation stores with one client. Each entry has a sprite, sense protocol metadata (delimiter / response_key / wrapper_tag / surfaces), and a slug-named .py mirror at a stable URL.",
+  "version": "1.0.0",
+  "generated_at": "2026-05-02T19:30:09Z",
+  "count": 5,
+  "self_url": "https://raw.githubusercontent.com/kody-w/RAPP_Sense_Store/main/api/v1/index.json",
+  "senses": [
+    {
+      "id": "rapp__eli5",
+      "name": "eli5",
+      "publisher": "@rapp",
+      "version": "0.1.0",
+      "delimiter": "|||ELI5|||",
+      "wrapper_tag": "eli5",
+      "surfaces": [
+        "chat"
+      ],
+      "url": "https://raw.githubusercontent.com/kody-w/RAPP_Sense_Store/main/api/v1/sense/rapp__eli5.json",
+      "sprite": "https://raw.githubusercontent.com/kody-w/RAPP_Sense_Store/main/api/v1/sprite/rapp__eli5.svg",
+      "py": "https://raw.githubusercontent.com/kody-w/RAPP_Sense_Store/main/api/v1/sense/rapp__eli5.py"
+    },
+    {
+      "id": "rapp__emoji",
+      "name": "emoji",
+      "publisher": "@rapp",
+      "version": "0.1.0",
+      "delimiter": "|||EMOJI|||",
+      "wrapper_tag": "emoji",
+      "surfaces": [
+        "chat"
+      ],
+      "url": "https://raw.githubusercontent.com/kody-w/RAPP_Sense_Store/main/api/v1/sense/rapp__emoji.json",
+      "sprite": "https://raw.githubusercontent.com/kody-w/RAPP_Sense_Store/main/api/v1/sprite/rapp__emoji.svg",
+      "py": "https://raw.githubusercontent.com/kody-w/RAPP_Sense_Store/main/api/v1/sense/rapp__emoji.py"
+    },
+    {
+      "id": "rapp__haiku",
+      "name": "haiku",
+      "publisher": "@rapp",
+      "version": "0.1.0",
+      "delimiter": "|||HAIKU|||",
+      "wrapper_tag": "haiku",
+      "surfaces": [
+        "chat"
+      ],
+      "url": "https://raw.githubusercontent.com/kody-w/RAPP_Sense_Store/main/api/v1/sense/rapp__haiku.json",
+      "sprite": "https://raw.githubusercontent.com/kody-w/RAPP_Sense_Store/main/api/v1/sprite/rapp__haiku.svg",
+      "py": "https://raw.githubusercontent.com/kody-w/RAPP_Sense_Store/main/api/v1/sense/rapp__haiku.py"
+    },
+    {
+      "id": "rapp__headline",
+      "name": "headline",
+      "publisher": "@rapp",
+      "version": "0.1.0",
+      "delimiter": "|||HEADLINE|||",
+      "wrapper_tag": "headline",
+      "surfaces": [
+        "chat"
+      ],
+      "url": "https://raw.githubusercontent.com/kody-w/RAPP_Sense_Store/main/api/v1/sense/rapp__headline.json",
+      "sprite": "https://raw.githubusercontent.com/kody-w/RAPP_Sense_Store/main/api/v1/sprite/rapp__headline.svg",
+      "py": "https://raw.githubusercontent.com/kody-w/RAPP_Sense_Store/main/api/v1/sense/rapp__headline.py"
+    },
+    {
+      "id": "rapp__tldr",
+      "name": "tldr",
+      "publisher": "@rapp",
+      "version": "0.1.0",
+      "delimiter": "|||TLDR|||",
+      "wrapper_tag": "tldr",
+      "surfaces": [
+        "chat"
+      ],
+      "url": "https://raw.githubusercontent.com/kody-w/RAPP_Sense_Store/main/api/v1/sense/rapp__tldr.json",
+      "sprite": "https://raw.githubusercontent.com/kody-w/RAPP_Sense_Store/main/api/v1/sprite/rapp__tldr.svg",
+      "py": "https://raw.githubusercontent.com/kody-w/RAPP_Sense_Store/main/api/v1/sense/rapp__tldr.py"
+    }
+  ]
+}

--- a/api/v1/sense/rapp__eli5.json
+++ b/api/v1/sense/rapp__eli5.json
@@ -1,0 +1,23 @@
+{
+  "schema": "rapp-sense-pokedex-sense/1.0",
+  "id": "rapp__eli5",
+  "name": "eli5",
+  "rappid": "rappid:v2:sense:@rapp/eli5:ceba5ec8d193bc077243eb14bf6b72b0",
+  "version": "0.1.0",
+  "publisher": "@rapp",
+  "description": "ELI5 \u2014 the same response, explained to a five-year-old.",
+  "delimiter": "|||ELI5|||",
+  "response_key": "eli5_response",
+  "wrapper_tag": "eli5",
+  "surfaces": [
+    "chat"
+  ],
+  "filename": "eli5_sense.py",
+  "sha256": "ceba5ec8d193bc077243eb14bf6b72b0ae24b6588ab6feb4d8bddaab6546dd24",
+  "parent_rappid": "rappid:v2:prototype:@rapp/origin:0b635450c04249fbb4b1bdb571044dec@github.com/kody-w/RAPP",
+  "sprite_url": "https://raw.githubusercontent.com/kody-w/RAPP_Sense_Store/main/api/v1/sprite/rapp__eli5.svg",
+  "py_url": "https://raw.githubusercontent.com/kody-w/RAPP_Sense_Store/main/senses/@rapp/eli5_sense.py",
+  "api_py_url": "https://raw.githubusercontent.com/kody-w/RAPP_Sense_Store/main/api/v1/sense/rapp__eli5.py",
+  "self_url": "https://raw.githubusercontent.com/kody-w/RAPP_Sense_Store/main/api/v1/sense/rapp__eli5.json",
+  "github_url": "https://github.com/kody-w/RAPP_Sense_Store/blob/main/senses/@rapp/eli5_sense.py"
+}

--- a/api/v1/sense/rapp__eli5.py
+++ b/api/v1/sense/rapp__eli5.py
@@ -1,0 +1,30 @@
+"""ELI5 — the same response, explained to a five-year-old.
+
+A sense that translates the main reply into a version a child could
+understand. Same answer, different audience. Frontends with an
+"explain it simply" toggle swap eli5_response in for the main reply;
+teaching/onboarding UIs render it as a side-by-side companion.
+
+Install: drop in rapp_brainstem/senses/. Restart not required.
+"""
+
+name = "eli5"
+delimiter = "|||ELI5|||"
+response_key = "eli5_response"
+wrapper_tag = "eli5"
+system_prompt = (
+    "After your main reply, append `|||ELI5|||` followed by an "
+    "explain-like-I'm-five version of the same answer. Short sentences. "
+    "Concrete nouns. No jargon — if you must use a technical term, "
+    "translate it inline (\"a cookie, which is a tiny note your browser "
+    "remembers\"). Analogies welcome, especially physical ones. 2-4 "
+    "sentences ideal. The ELI5 is a TRANSLATION — the same meaning, "
+    "different audience. Always emit — empty is not allowed."
+)
+
+__manifest__ = {
+    "schema": "rapp-sense/1.0",
+    "name": "@rapp/eli5",
+    "version": "0.1.0",
+    "description": "ELI5 \u2014 the same response, explained to a five-year-old.",
+}

--- a/api/v1/sense/rapp__emoji.json
+++ b/api/v1/sense/rapp__emoji.json
@@ -1,0 +1,23 @@
+{
+  "schema": "rapp-sense-pokedex-sense/1.0",
+  "id": "rapp__emoji",
+  "name": "emoji",
+  "rappid": "rappid:v2:sense:@rapp/emoji:7416feef480c2773a2133e3491b104a4",
+  "version": "0.1.0",
+  "publisher": "@rapp",
+  "description": "EMOJI \u2014 the same response, as an emoji sequence.",
+  "delimiter": "|||EMOJI|||",
+  "response_key": "emoji_response",
+  "wrapper_tag": "emoji",
+  "surfaces": [
+    "chat"
+  ],
+  "filename": "emoji_sense.py",
+  "sha256": "7416feef480c2773a2133e3491b104a4aaf0e8a6ccfb97898e474ff69a476841",
+  "parent_rappid": "rappid:v2:prototype:@rapp/origin:0b635450c04249fbb4b1bdb571044dec@github.com/kody-w/RAPP",
+  "sprite_url": "https://raw.githubusercontent.com/kody-w/RAPP_Sense_Store/main/api/v1/sprite/rapp__emoji.svg",
+  "py_url": "https://raw.githubusercontent.com/kody-w/RAPP_Sense_Store/main/senses/@rapp/emoji_sense.py",
+  "api_py_url": "https://raw.githubusercontent.com/kody-w/RAPP_Sense_Store/main/api/v1/sense/rapp__emoji.py",
+  "self_url": "https://raw.githubusercontent.com/kody-w/RAPP_Sense_Store/main/api/v1/sense/rapp__emoji.json",
+  "github_url": "https://github.com/kody-w/RAPP_Sense_Store/blob/main/senses/@rapp/emoji_sense.py"
+}

--- a/api/v1/sense/rapp__emoji.py
+++ b/api/v1/sense/rapp__emoji.py
@@ -1,0 +1,30 @@
+"""EMOJI — the same response, as an emoji sequence.
+
+A sense that translates the main reply into a sequence of emoji that
+tells the same story. Frontends with chat-bubble UIs render this above
+or alongside the prose; teaches accessibility tools an at-a-glance
+summary; works as a tone fingerprint for the response.
+
+Install: drop in rapp_brainstem/senses/. Restart not required.
+"""
+
+name = "emoji"
+delimiter = "|||EMOJI|||"
+response_key = "emoji_response"
+wrapper_tag = "emoji"
+system_prompt = (
+    "After your main reply, append `|||EMOJI|||` followed by 3-7 emoji "
+    "that together tell the same story as your answer. Read left-to-right "
+    "as a tiny narrative or as a thematic chord. No spaces between emoji, "
+    "no commentary, no text — just the emoji. The sequence is a "
+    "TRANSLATION of the answer into pictographic form. Always emit — "
+    "if the answer is purely abstract, pick emoji that capture its mood "
+    "or shape."
+)
+
+__manifest__ = {
+    "schema": "rapp-sense/1.0",
+    "name": "@rapp/emoji",
+    "version": "0.1.0",
+    "description": "EMOJI \u2014 the same response, as an emoji sequence.",
+}

--- a/api/v1/sense/rapp__haiku.json
+++ b/api/v1/sense/rapp__haiku.json
@@ -1,0 +1,23 @@
+{
+  "schema": "rapp-sense-pokedex-sense/1.0",
+  "id": "rapp__haiku",
+  "name": "haiku",
+  "rappid": "rappid:v2:sense:@rapp/haiku:e9069493ae4302176bbbc4aaecea2b62",
+  "version": "0.1.0",
+  "publisher": "@rapp",
+  "description": "HAIKU \u2014 the same response, as a 5-7-5 poem.",
+  "delimiter": "|||HAIKU|||",
+  "response_key": "haiku_response",
+  "wrapper_tag": "haiku",
+  "surfaces": [
+    "chat"
+  ],
+  "filename": "haiku_sense.py",
+  "sha256": "e9069493ae4302176bbbc4aaecea2b62a5f547c6b0f9f83b2633f0172a082663",
+  "parent_rappid": "rappid:v2:prototype:@rapp/origin:0b635450c04249fbb4b1bdb571044dec@github.com/kody-w/RAPP",
+  "sprite_url": "https://raw.githubusercontent.com/kody-w/RAPP_Sense_Store/main/api/v1/sprite/rapp__haiku.svg",
+  "py_url": "https://raw.githubusercontent.com/kody-w/RAPP_Sense_Store/main/senses/@rapp/haiku_sense.py",
+  "api_py_url": "https://raw.githubusercontent.com/kody-w/RAPP_Sense_Store/main/api/v1/sense/rapp__haiku.py",
+  "self_url": "https://raw.githubusercontent.com/kody-w/RAPP_Sense_Store/main/api/v1/sense/rapp__haiku.json",
+  "github_url": "https://github.com/kody-w/RAPP_Sense_Store/blob/main/senses/@rapp/haiku_sense.py"
+}

--- a/api/v1/sense/rapp__haiku.py
+++ b/api/v1/sense/rapp__haiku.py
@@ -1,0 +1,29 @@
+"""HAIKU — the same response, as a 5-7-5 poem.
+
+A sense that translates the main reply into a single haiku. Frontends
+that want a "poetic mode" pin haiku_response below the main reply, or
+swap it in entirely for a contemplative UI.
+
+Install: drop in rapp_brainstem/senses/. Restart not required.
+"""
+
+name = "haiku"
+delimiter = "|||HAIKU|||"
+response_key = "haiku_response"
+wrapper_tag = "haiku"
+system_prompt = (
+    "After your main reply, append `|||HAIKU|||` followed by a single "
+    "haiku that captures the essence of your answer. Strict 5/7/5 "
+    "syllable count, three lines, no title, no commentary. The haiku "
+    "is a TRANSLATION of the answer into poetic form — same meaning, "
+    "different mode. If the answer cannot meaningfully compress to a "
+    "haiku, write one about the gap between question and answer instead. "
+    "Always emit a haiku — empty is not allowed."
+)
+
+__manifest__ = {
+    "schema": "rapp-sense/1.0",
+    "name": "@rapp/haiku",
+    "version": "0.1.0",
+    "description": "HAIKU \u2014 the same response, as a 5-7-5 poem.",
+}

--- a/api/v1/sense/rapp__headline.json
+++ b/api/v1/sense/rapp__headline.json
@@ -1,0 +1,23 @@
+{
+  "schema": "rapp-sense-pokedex-sense/1.0",
+  "id": "rapp__headline",
+  "name": "headline",
+  "rappid": "rappid:v2:sense:@rapp/headline:641d3bbd3d8a5826d0c9f99c4db39c51",
+  "version": "0.1.0",
+  "publisher": "@rapp",
+  "description": "HEADLINE \u2014 the same response, as a news headline.",
+  "delimiter": "|||HEADLINE|||",
+  "response_key": "headline_response",
+  "wrapper_tag": "headline",
+  "surfaces": [
+    "chat"
+  ],
+  "filename": "headline_sense.py",
+  "sha256": "641d3bbd3d8a5826d0c9f99c4db39c514728bf974d6982f3de250a081584e228",
+  "parent_rappid": "rappid:v2:prototype:@rapp/origin:0b635450c04249fbb4b1bdb571044dec@github.com/kody-w/RAPP",
+  "sprite_url": "https://raw.githubusercontent.com/kody-w/RAPP_Sense_Store/main/api/v1/sprite/rapp__headline.svg",
+  "py_url": "https://raw.githubusercontent.com/kody-w/RAPP_Sense_Store/main/senses/@rapp/headline_sense.py",
+  "api_py_url": "https://raw.githubusercontent.com/kody-w/RAPP_Sense_Store/main/api/v1/sense/rapp__headline.py",
+  "self_url": "https://raw.githubusercontent.com/kody-w/RAPP_Sense_Store/main/api/v1/sense/rapp__headline.json",
+  "github_url": "https://github.com/kody-w/RAPP_Sense_Store/blob/main/senses/@rapp/headline_sense.py"
+}

--- a/api/v1/sense/rapp__headline.py
+++ b/api/v1/sense/rapp__headline.py
@@ -1,0 +1,28 @@
+"""HEADLINE — the same response, as a news headline.
+
+A sense that translates the main reply into a punchy headline. For
+notification UIs, push-style summaries, dashboard cards, anywhere a
+glanceable hook beats prose. Verb-driven, present tense, no clickbait.
+
+Install: drop in rapp_brainstem/senses/. Restart not required.
+"""
+
+name = "headline"
+delimiter = "|||HEADLINE|||"
+response_key = "headline_response"
+wrapper_tag = "headline"
+system_prompt = (
+    "After your main reply, append `|||HEADLINE|||` followed by a single "
+    "headline that captures the answer's essence the way a news ticker "
+    "would. Verb-driven. Present tense. Under 10 words. Title case is "
+    "fine but not required. No clickbait, no rhetorical questions, no "
+    "ellipses. The headline is a TRANSLATION of the answer into "
+    "attention-grabbing form. Always emit — empty is not allowed."
+)
+
+__manifest__ = {
+    "schema": "rapp-sense/1.0",
+    "name": "@rapp/headline",
+    "version": "0.1.0",
+    "description": "HEADLINE \u2014 the same response, as a news headline.",
+}

--- a/api/v1/sense/rapp__tldr.json
+++ b/api/v1/sense/rapp__tldr.json
@@ -1,0 +1,23 @@
+{
+  "schema": "rapp-sense-pokedex-sense/1.0",
+  "id": "rapp__tldr",
+  "name": "tldr",
+  "rappid": "rappid:v2:sense:@rapp/tldr:7d3e1d55bf74644ccfaf937fcee7670e",
+  "version": "0.1.0",
+  "publisher": "@rapp",
+  "description": "TLDR \u2014 the same response, compressed to one sentence.",
+  "delimiter": "|||TLDR|||",
+  "response_key": "tldr_response",
+  "wrapper_tag": "tldr",
+  "surfaces": [
+    "chat"
+  ],
+  "filename": "tldr_sense.py",
+  "sha256": "7d3e1d55bf74644ccfaf937fcee7670e69f20cc535ebb17b0f1ecc9d1b45929e",
+  "parent_rappid": "rappid:v2:prototype:@rapp/origin:0b635450c04249fbb4b1bdb571044dec@github.com/kody-w/RAPP",
+  "sprite_url": "https://raw.githubusercontent.com/kody-w/RAPP_Sense_Store/main/api/v1/sprite/rapp__tldr.svg",
+  "py_url": "https://raw.githubusercontent.com/kody-w/RAPP_Sense_Store/main/senses/@rapp/tldr_sense.py",
+  "api_py_url": "https://raw.githubusercontent.com/kody-w/RAPP_Sense_Store/main/api/v1/sense/rapp__tldr.py",
+  "self_url": "https://raw.githubusercontent.com/kody-w/RAPP_Sense_Store/main/api/v1/sense/rapp__tldr.json",
+  "github_url": "https://github.com/kody-w/RAPP_Sense_Store/blob/main/senses/@rapp/tldr_sense.py"
+}

--- a/api/v1/sense/rapp__tldr.py
+++ b/api/v1/sense/rapp__tldr.py
@@ -1,0 +1,29 @@
+"""TLDR — the same response, compressed to one sentence.
+
+A sense that translates the main reply into a single declarative
+sentence. For UIs that show a one-line preview, mobile shells with
+limited screen real estate, or anywhere "what's the point of this
+answer" matters more than the answer itself.
+
+Install: drop in rapp_brainstem/senses/. Restart not required.
+"""
+
+name = "tldr"
+delimiter = "|||TLDR|||"
+response_key = "tldr_response"
+wrapper_tag = "tldr"
+system_prompt = (
+    "After your main reply, append `|||TLDR|||` followed by exactly one "
+    "sentence that captures the load-bearing point of your answer. No "
+    "preamble, no list, no qualifier (\"basically\", \"in short\", "
+    "\"essentially\" — none of these). One sentence, period. The sentence "
+    "is the answer's spine — what survives if everything else is cut. "
+    "Always emit — empty is not allowed."
+)
+
+__manifest__ = {
+    "schema": "rapp-sense/1.0",
+    "name": "@rapp/tldr",
+    "version": "0.1.0",
+    "description": "TLDR \u2014 the same response, compressed to one sentence.",
+}

--- a/api/v1/sprite/rapp__eli5.svg
+++ b/api/v1/sprite/rapp__eli5.svg
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="192" height="192" shape-rendering="crispEdges">
+  <rect width="48" height="48" fill="#1a7f37" opacity="0.25"/>
+  <rect x="0" y="0" width="8" height="8" fill="#1a7f37"/>
+  <rect x="40" y="0" width="8" height="8" fill="#1a7f37"/>
+  <rect x="8" y="0" width="8" height="8" fill="#1a7f37"/>
+  <rect x="32" y="0" width="8" height="8" fill="#1a7f37"/>
+  <rect x="16" y="0" width="8" height="8" fill="#1a7f37"/>
+  <rect x="24" y="0" width="8" height="8" fill="#1a7f37"/>
+  <rect x="0" y="8" width="8" height="8" fill="#1a7f37"/>
+  <rect x="40" y="8" width="8" height="8" fill="#1a7f37"/>
+  <rect x="8" y="8" width="8" height="8" fill="#1a7f37"/>
+  <rect x="32" y="8" width="8" height="8" fill="#1a7f37"/>
+  <rect x="16" y="8" width="8" height="8" fill="#1a7f37"/>
+  <rect x="24" y="8" width="8" height="8" fill="#1a7f37"/>
+  <rect x="16" y="16" width="8" height="8" fill="#1a7f37"/>
+  <rect x="24" y="16" width="8" height="8" fill="#1a7f37"/>
+  <rect x="0" y="24" width="8" height="8" fill="#1a7f37"/>
+  <rect x="40" y="24" width="8" height="8" fill="#1a7f37"/>
+  <rect x="8" y="32" width="8" height="8" fill="#1a7f37"/>
+  <rect x="32" y="32" width="8" height="8" fill="#1a7f37"/>
+  <rect x="0" y="40" width="8" height="8" fill="#1a7f37"/>
+  <rect x="40" y="40" width="8" height="8" fill="#1a7f37"/>
+  <rect x="8" y="40" width="8" height="8" fill="#1a7f37"/>
+  <rect x="32" y="40" width="8" height="8" fill="#1a7f37"/>
+</svg>

--- a/api/v1/sprite/rapp__emoji.svg
+++ b/api/v1/sprite/rapp__emoji.svg
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="192" height="192" shape-rendering="crispEdges">
+  <rect width="48" height="48" fill="#7df0c8" opacity="0.25"/>
+  <rect x="0" y="0" width="8" height="8" fill="#3fb950"/>
+  <rect x="40" y="0" width="8" height="8" fill="#3fb950"/>
+  <rect x="8" y="0" width="8" height="8" fill="#3fb950"/>
+  <rect x="32" y="0" width="8" height="8" fill="#3fb950"/>
+  <rect x="16" y="0" width="8" height="8" fill="#3fb950"/>
+  <rect x="24" y="0" width="8" height="8" fill="#3fb950"/>
+  <rect x="8" y="8" width="8" height="8" fill="#3fb950"/>
+  <rect x="32" y="8" width="8" height="8" fill="#3fb950"/>
+  <rect x="16" y="8" width="8" height="8" fill="#3fb950"/>
+  <rect x="24" y="8" width="8" height="8" fill="#3fb950"/>
+  <rect x="8" y="16" width="8" height="8" fill="#3fb950"/>
+  <rect x="32" y="16" width="8" height="8" fill="#3fb950"/>
+  <rect x="16" y="16" width="8" height="8" fill="#3fb950"/>
+  <rect x="24" y="16" width="8" height="8" fill="#3fb950"/>
+  <rect x="0" y="24" width="8" height="8" fill="#3fb950"/>
+  <rect x="40" y="24" width="8" height="8" fill="#3fb950"/>
+  <rect x="8" y="24" width="8" height="8" fill="#3fb950"/>
+  <rect x="32" y="24" width="8" height="8" fill="#3fb950"/>
+  <rect x="16" y="24" width="8" height="8" fill="#3fb950"/>
+  <rect x="24" y="24" width="8" height="8" fill="#3fb950"/>
+  <rect x="0" y="32" width="8" height="8" fill="#3fb950"/>
+  <rect x="40" y="32" width="8" height="8" fill="#3fb950"/>
+  <rect x="8" y="32" width="8" height="8" fill="#3fb950"/>
+  <rect x="32" y="32" width="8" height="8" fill="#3fb950"/>
+  <rect x="16" y="32" width="8" height="8" fill="#3fb950"/>
+  <rect x="24" y="32" width="8" height="8" fill="#3fb950"/>
+  <rect x="0" y="40" width="8" height="8" fill="#3fb950"/>
+  <rect x="40" y="40" width="8" height="8" fill="#3fb950"/>
+  <rect x="16" y="40" width="8" height="8" fill="#3fb950"/>
+  <rect x="24" y="40" width="8" height="8" fill="#3fb950"/>
+</svg>

--- a/api/v1/sprite/rapp__haiku.svg
+++ b/api/v1/sprite/rapp__haiku.svg
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="192" height="192" shape-rendering="crispEdges">
+  <rect width="48" height="48" fill="#7df0c8" opacity="0.25"/>
+  <rect x="0" y="0" width="8" height="8" fill="#7df0c8"/>
+  <rect x="40" y="0" width="8" height="8" fill="#7df0c8"/>
+  <rect x="8" y="0" width="8" height="8" fill="#7df0c8"/>
+  <rect x="32" y="0" width="8" height="8" fill="#7df0c8"/>
+  <rect x="16" y="0" width="8" height="8" fill="#7df0c8"/>
+  <rect x="24" y="0" width="8" height="8" fill="#7df0c8"/>
+  <rect x="0" y="8" width="8" height="8" fill="#7df0c8"/>
+  <rect x="40" y="8" width="8" height="8" fill="#7df0c8"/>
+  <rect x="16" y="8" width="8" height="8" fill="#7df0c8"/>
+  <rect x="24" y="8" width="8" height="8" fill="#7df0c8"/>
+  <rect x="16" y="16" width="8" height="8" fill="#7df0c8"/>
+  <rect x="24" y="16" width="8" height="8" fill="#7df0c8"/>
+  <rect x="0" y="24" width="8" height="8" fill="#7df0c8"/>
+  <rect x="40" y="24" width="8" height="8" fill="#7df0c8"/>
+  <rect x="8" y="24" width="8" height="8" fill="#7df0c8"/>
+  <rect x="32" y="24" width="8" height="8" fill="#7df0c8"/>
+  <rect x="0" y="32" width="8" height="8" fill="#7df0c8"/>
+  <rect x="40" y="32" width="8" height="8" fill="#7df0c8"/>
+  <rect x="0" y="40" width="8" height="8" fill="#7df0c8"/>
+  <rect x="40" y="40" width="8" height="8" fill="#7df0c8"/>
+  <rect x="8" y="40" width="8" height="8" fill="#7df0c8"/>
+  <rect x="32" y="40" width="8" height="8" fill="#7df0c8"/>
+  <rect x="16" y="40" width="8" height="8" fill="#7df0c8"/>
+  <rect x="24" y="40" width="8" height="8" fill="#7df0c8"/>
+</svg>

--- a/api/v1/sprite/rapp__headline.svg
+++ b/api/v1/sprite/rapp__headline.svg
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="192" height="192" shape-rendering="crispEdges">
+  <rect width="48" height="48" fill="#7df0c8" opacity="0.25"/>
+  <rect x="0" y="0" width="8" height="8" fill="#7df0c8"/>
+  <rect x="40" y="0" width="8" height="8" fill="#7df0c8"/>
+  <rect x="8" y="0" width="8" height="8" fill="#7df0c8"/>
+  <rect x="32" y="0" width="8" height="8" fill="#7df0c8"/>
+  <rect x="16" y="0" width="8" height="8" fill="#7df0c8"/>
+  <rect x="24" y="0" width="8" height="8" fill="#7df0c8"/>
+  <rect x="0" y="8" width="8" height="8" fill="#7df0c8"/>
+  <rect x="40" y="8" width="8" height="8" fill="#7df0c8"/>
+  <rect x="16" y="16" width="8" height="8" fill="#7df0c8"/>
+  <rect x="24" y="16" width="8" height="8" fill="#7df0c8"/>
+  <rect x="16" y="24" width="8" height="8" fill="#7df0c8"/>
+  <rect x="24" y="24" width="8" height="8" fill="#7df0c8"/>
+  <rect x="0" y="40" width="8" height="8" fill="#7df0c8"/>
+  <rect x="40" y="40" width="8" height="8" fill="#7df0c8"/>
+</svg>

--- a/api/v1/sprite/rapp__tldr.svg
+++ b/api/v1/sprite/rapp__tldr.svg
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="192" height="192" shape-rendering="crispEdges">
+  <rect width="48" height="48" fill="#7df0c8" opacity="0.25"/>
+  <rect x="8" y="0" width="8" height="8" fill="#1a7f37"/>
+  <rect x="32" y="0" width="8" height="8" fill="#1a7f37"/>
+  <rect x="8" y="8" width="8" height="8" fill="#1a7f37"/>
+  <rect x="32" y="8" width="8" height="8" fill="#1a7f37"/>
+  <rect x="0" y="16" width="8" height="8" fill="#1a7f37"/>
+  <rect x="40" y="16" width="8" height="8" fill="#1a7f37"/>
+  <rect x="0" y="24" width="8" height="8" fill="#1a7f37"/>
+  <rect x="40" y="24" width="8" height="8" fill="#1a7f37"/>
+  <rect x="16" y="24" width="8" height="8" fill="#1a7f37"/>
+  <rect x="24" y="24" width="8" height="8" fill="#1a7f37"/>
+  <rect x="0" y="32" width="8" height="8" fill="#1a7f37"/>
+  <rect x="40" y="32" width="8" height="8" fill="#1a7f37"/>
+  <rect x="8" y="32" width="8" height="8" fill="#1a7f37"/>
+  <rect x="32" y="32" width="8" height="8" fill="#1a7f37"/>
+  <rect x="0" y="40" width="8" height="8" fill="#1a7f37"/>
+  <rect x="40" y="40" width="8" height="8" fill="#1a7f37"/>
+  <rect x="8" y="40" width="8" height="8" fill="#1a7f37"/>
+  <rect x="32" y="40" width="8" height="8" fill="#1a7f37"/>
+</svg>

--- a/scripts/build_pokedex_api.py
+++ b/scripts/build_pokedex_api.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""
+build_pokedex_api.py — generate the static RAPP_Sense_Store Pokédex API.
+
+Mirrors kody-w/RAPP_Store + kody-w/RAR's Pokédex APIs (same shape,
+applied to sense overlays). Modeled on PokeAPI: predictable static
+URLs, no backend.
+
+URL shape (relative to repo root, all under api/v1/):
+
+    api/v1/index.json                    — paginated list + counts
+    api/v1/sense/<id>.json               — single sense entry
+    api/v1/sense/<id>.py                 — slug-named mirror of the .py
+    api/v1/sprite/<id>.svg               — deterministic generative sprite
+
+Where <id> is `<publisher>__<sense_name>` (URL-safe).
+
+Sources `index.json` (existing source of truth) — each entry already
+carries the sense protocol fields (delimiter / response_key /
+wrapper_tag / surfaces / description / sha256). No registry rebuild
+needed; this is a pure transformation.
+
+The rapp-zoo Discover tab fetches from this + RAPP_Store + RAR and
+renders the union as one Pokédex. Per Article XXXVII, every entry is
+an organism; the catalog of choice is just where the user's eye lands.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+import sys
+import time
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parent.parent
+_INDEX_SRC = _REPO / "index.json"
+_API = _REPO / "api" / "v1"
+
+SCHEMA_API_INDEX = "rapp-sense-pokedex-api/1.0"
+SCHEMA_API_SENSE = "rapp-sense-pokedex-sense/1.0"
+RAW_PREFIX = "https://raw.githubusercontent.com/kody-w/RAPP_Sense_Store/main"
+
+
+def _now_iso() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+def _slug(publisher: str, name: str) -> str:
+    pub = publisher[1:] if publisher.startswith("@") else publisher
+    return f"{pub}__{name}".replace("/", "_")
+
+
+PALETTES = {
+    "default":   ["#7df0c8", "#3fb950", "#1a7f37"],   # mint family — senses are perception channels
+    "voice":     ["#79c0ff", "#58a6ff", "#0969da"],
+    "twin":      ["#b58ddf", "#a78bfa", "#8250df"],
+    "summary":   ["#ffa657", "#f78166", "#bc4c00"],
+}
+
+
+def _sprite_svg(seed: str, name_for_palette: str = "default") -> str:
+    palette_key = "default"
+    for k in PALETTES:
+        if k != "default" and k in name_for_palette.lower():
+            palette_key = k
+            break
+    palette = PALETTES[palette_key]
+    h = abs(int(hashlib.sha256(seed.encode()).hexdigest()[:8], 16))
+    fg = palette[h % 3]
+    bg = palette[(h >> 4) % 3]
+    rects = []
+    for y in range(6):
+        for x in range(3):
+            bit = (h >> ((y * 3 + x) % 28)) & 1
+            if bit:
+                rects.append(f'<rect x="{x*8}" y="{y*8}" width="8" height="8" fill="{fg}"/>')
+                rects.append(f'<rect x="{(5-x)*8}" y="{y*8}" width="8" height="8" fill="{fg}"/>')
+    return (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="192" height="192" shape-rendering="crispEdges">\n'
+        f'  <rect width="48" height="48" fill="{bg}" opacity="0.25"/>\n'
+        + "  " + "\n  ".join(rects) + "\n</svg>\n"
+    )
+
+
+def _build_entry(sense: dict) -> dict:
+    name = sense["name"]
+    publisher = sense.get("publisher", "@anon")
+    slug = _slug(publisher, name)
+    sha = sense.get("sha256") or ""
+    rappid = f"rappid:v2:sense:{publisher}/{name}:{(sha or slug)[:32]}"
+
+    return {
+        "schema": SCHEMA_API_SENSE,
+        "id": slug,
+        "name": name,
+        "rappid": rappid,
+        "version": sense.get("version", "0.0.0"),
+        "publisher": publisher,
+        "description": sense.get("description"),
+
+        # Sense protocol fields — what the kernel needs to know
+        "delimiter":    sense.get("delimiter"),
+        "response_key": sense.get("response_key"),
+        "wrapper_tag":  sense.get("wrapper_tag"),
+        "surfaces":     sense.get("surfaces", []),
+
+        # Stats
+        "filename": sense.get("filename"),
+        "sha256":   sha,
+
+        # Lineage
+        "parent_rappid": "rappid:v2:prototype:@rapp/origin:0b635450c04249fbb4b1bdb571044dec@github.com/kody-w/RAPP",
+
+        # Asset URLs
+        "sprite_url": f"{RAW_PREFIX}/api/v1/sprite/{slug}.svg",
+        "py_url":     sense.get("url"),                                # original namespaced
+        "api_py_url": f"{RAW_PREFIX}/api/v1/sense/{slug}.py",          # slug-named mirror
+        "self_url":   f"{RAW_PREFIX}/api/v1/sense/{slug}.json",
+        "github_url": f"https://github.com/kody-w/RAPP_Sense_Store/blob/main/senses/{publisher}/{sense.get('filename','')}",
+    }
+
+
+def main():
+    if not _INDEX_SRC.is_file():
+        print(f"err: index.json not found at {_INDEX_SRC}", file=sys.stderr)
+        sys.exit(1)
+
+    if _API.exists():
+        shutil.rmtree(_API)
+    (_API / "sense").mkdir(parents=True)
+    (_API / "sprite").mkdir(parents=True)
+
+    src_index = json.loads(_INDEX_SRC.read_text())
+    senses = src_index.get("senses", [])
+
+    entries = []
+    for sense in senses:
+        entry = _build_entry(sense)
+        slug = entry["id"]
+        entries.append(entry)
+        (_API / "sense" / f"{slug}.json").write_text(json.dumps(entry, indent=2) + "\n")
+        (_API / "sprite" / f"{slug}.svg").write_text(_sprite_svg(entry["rappid"], entry["name"]))
+        # Mirror the .py at a slug-named URL for stable fetching
+        publisher = entry["publisher"]
+        fname = entry.get("filename")
+        if fname:
+            src_py = _REPO / "senses" / publisher / fname
+            if src_py.is_file():
+                (_API / "sense" / f"{slug}.py").write_bytes(src_py.read_bytes())
+        print(f"  ✓ {publisher}/{entry['name']:<14}  {entry.get('delimiter','?')}")
+
+    index = {
+        "schema": SCHEMA_API_INDEX,
+        "name": "RAPP_Sense_Store Pokédex API",
+        "description": (
+            "Static catalog API for RAPP sense overlays — per-channel "
+            "output transformers that the brainstem installs into "
+            "utils/senses/. Mirrors the RAPP_Store + RAR API shape so "
+            "the rapp-zoo can browse all federation stores with one "
+            "client. Each entry has a sprite, sense protocol metadata "
+            "(delimiter / response_key / wrapper_tag / surfaces), and "
+            "a slug-named .py mirror at a stable URL."
+        ),
+        "version": "1.0.0",
+        "generated_at": _now_iso(),
+        "count": len(entries),
+        "self_url":  f"{RAW_PREFIX}/api/v1/index.json",
+        "senses": [
+            {
+                "id":           e["id"],
+                "name":         e["name"],
+                "publisher":    e["publisher"],
+                "version":      e["version"],
+                "delimiter":    e["delimiter"],
+                "wrapper_tag":  e["wrapper_tag"],
+                "surfaces":     e["surfaces"],
+                "url":          e["self_url"],
+                "sprite":       e["sprite_url"],
+                "py":           e["api_py_url"],
+            }
+            for e in entries
+        ],
+    }
+    (_API / "index.json").write_text(json.dumps(index, indent=2) + "\n")
+
+    print()
+    print(f"  → wrote {len(entries)} sense entries to {_API.relative_to(_REPO)}/")
+    print(f"  → index: api/v1/index.json")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Same shape as RAPP_Store + RAR. 5 sense entries get sprites + JSON manifests + slug-named .py mirrors. The federation now has uniform static APIs at three repos; the rapp-zoo can browse the union of all three with one client.